### PR TITLE
Fix reference-style links in Installing-PowerShell-Core-on-Windows.md 

### DIFF
--- a/reference/docs-conceptual/install/Installing-PowerShell-Core-on-Windows.md
+++ b/reference/docs-conceptual/install/Installing-PowerShell-Core-on-Windows.md
@@ -154,4 +154,7 @@ PowerShell Core unterstützt das PowerShell-Remotingprotokoll (PSRP) über WSMan
 - [WSMan-Remoting in PowerShell Core][wsman-remoting]
 
 <!-- [download-center]: TODO -->
-[Releases]: https://github.com/PowerShell/PowerShell/releases [ssh-remoting]: ../core-powershell/SSH-Remoting-in-PowerShell-Core.md [wsman-remoting]: ../core-powershell/WSMan-Remoting-in-PowerShell-Core.md [AppVeyor]: https://ci.appveyor.com/project/PowerShell/powershell
+[Releases]: https://github.com/PowerShell/PowerShell/releases
+[ssh-remoting]: ../core-powershell/SSH-Remoting-in-PowerShell-Core.md
+[wsman-remoting]: ../core-powershell/WSMan-Remoting-in-PowerShell-Core.md
+[AppVeyor]: https://ci.appveyor.com/project/PowerShell/powershell


### PR DESCRIPTION
Reference style links has to be separated by linebreaks to be rendered correctly.

Expected Behaviour:

![grafik](https://user-images.githubusercontent.com/4380869/59253586-da474980-8c2e-11e9-825c-9c04f2876f24.png)

Current Behavior:

![grafik](https://user-images.githubusercontent.com/4380869/59253508-aff58c00-8c2e-11e9-95fe-84036b1b9e93.png)
